### PR TITLE
Update Homebox version references

### DIFF
--- a/example/CHANGELOG.md
+++ b/example/CHANGELOG.md
@@ -1,5 +1,9 @@
 <!-- https://developers.home-assistant.io/docs/add-ons/presentation#keeping-a-changelog -->
 
+## 2.0.4
+
+- Updated Homebox base image references to version 0.17
+
 ## 2.0.3
 
 - Cleaned up metadata and documentation for the Homebox add-on

--- a/example/build.yaml
+++ b/example/build.yaml
@@ -1,8 +1,8 @@
 # https://developers.home-assistant.io/docs/add-ons/configuration#add-on-dockerfile
 build_from:
-  aarch64: "ghcr.io/sysadminsmedia/homebox:0.16-arm"
-  amd64: "ghcr.io/sysadminsmedia/homebox:latest"
-  armv7: "ghcr.io/sysadminsmedia/homebox:0.16-arm"
+  aarch64: "ghcr.io/sysadminsmedia/homebox:0.17-arm"
+  amd64: "ghcr.io/sysadminsmedia/homebox:0.17"
+  armv7: "ghcr.io/sysadminsmedia/homebox:0.17-arm"
 labels:
   org.opencontainers.image.title: "Home Assistant Add-on: Homebox"
   org.opencontainers.image.description: "Run Homebox inside Home Assistant"

--- a/example/config.yaml
+++ b/example/config.yaml
@@ -1,6 +1,6 @@
 # https://developers.home-assistant.io/docs/add-ons/configuration#add-on-config
 name: Homebox Add-on
-version: "2.0.3"
+version: "2.0.4"
 slug: homebox
 description: Run Homebox inventory inside Home Assistant
 url: "https://github.com/jscarrott/homebox-addon"


### PR DESCRIPTION
## Summary
- bump the Homebox add-on version to 2.0.4
- update Homebox base image references to version 0.17 for all architectures
- record the version change in the changelog

## Testing
- not run (not available)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695be7dfd1248328b800780de6b4b6da)