### PR TITLE
Allow Homebox to start without config.yml (use defaults) and use /data/tmp for temp files

### DIFF
--- a/example/DOCS.md
+++ b/example/DOCS.md
@@ -6,10 +6,11 @@ This add-on packages [Homebox](https://github.com/sysadminsmedia/homebox), a sel
 
 ## Configuration
 
-Homebox expects a YAML configuration file at `/data/config.yml` inside the add-on container. You can create this file with the [File Editor](https://my.home-assistant.io/redirect/hassio_addon/?addon=a0d7b954_file_editor) add-on or any other method you prefer. If the file is missing, the add-on will stop during startup and log an error.
+Homebox can read an optional YAML configuration file at `/data/config.yml` inside the add-on container. You can create this file with the [File Editor](https://my.home-assistant.io/redirect/hassio_addon/?addon=a0d7b954_file_editor) add-on or any other method you prefer; if it is missing, the add-on will start with defaults.
 
 You can expose the web interface to your network by keeping the default port mapping `7745 -> 7745` or by adjusting it within the add-on options.
 
 ## Data persistence
 
 The add-on stores its configuration and Homebox database under `/data` so that your inventory persists across restarts and upgrades.
+Temporary files (including database migrations) are stored under `/data/tmp` to avoid permission issues with the system `/tmp`.

--- a/example/rootfs/etc/cont-init.d/10-ensure-config.sh
+++ b/example/rootfs/etc/cont-init.d/10-ensure-config.sh
@@ -2,8 +2,15 @@
 # Ensure a Homebox configuration file exists before starting the service
 
 CONFIG_FILE="/data/config.yml"
+TMP_DIR="/data/tmp"
 
 if ! bashio::fs.file_exists "${CONFIG_FILE}"; then
-  bashio::log.fatal "Missing Homebox configuration at ${CONFIG_FILE}. Create the file before starting the add-on."
-  exit 1
+  bashio::log.warning "Missing Homebox configuration at ${CONFIG_FILE}; starting with defaults."
 fi
+
+if ! bashio::fs.directory_exists "${TMP_DIR}"; then
+  bashio::log.info "Creating temporary directory at ${TMP_DIR}"
+  mkdir -p "${TMP_DIR}"
+fi
+
+chmod 1777 "${TMP_DIR}"

--- a/example/rootfs/etc/services.d/homebox/run
+++ b/example/rootfs/etc/services.d/homebox/run
@@ -2,4 +2,9 @@
 # Start the Homebox service
 
 bashio::log.info "Starting Homebox"
-exec /app/api /data/config.yml
+export TMPDIR="/data/tmp"
+if bashio::fs.file_exists "/data/config.yml"; then
+  exec /app/api /data/config.yml
+fi
+
+exec /app/api


### PR DESCRIPTION
### Motivation

- Prevent the add-on from failing startup when `/data/config.yml` is absent so Homebox can run with reasonable defaults.
- Ensure temporary files and migrations use a persisted directory to avoid permission issues with the system `/tmp` inside the add-on container.

### Description

- Changed the config check in `example/rootfs/etc/cont-init.d/10-ensure-config.sh` to log a warning instead of calling `exit 1` when `/data/config.yml` is missing.
- Ensure the persisted temp directory `/data/tmp` is created (if missing) and set to mode `1777` in `10-ensure-config.sh`.
- Updated `example/rootfs/etc/services.d/homebox/run` to `export TMPDIR="/data/tmp"` and to start `exec /app/api /data/config.yml` only when `/data/config.yml` exists, otherwise `exec /app/api` is used.
- Updated `example/DOCS.md` to document that `/data/config.yml` is optional and that temporary files are stored under `/data/tmp`.

### Testing

- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69696158bcc083289be63e9caacadedf)