### PR TITLE
Fix Homebox startup crash by setting TMPDIR to /data

### DIFF
--- a/example/CHANGELOG.md
+++ b/example/CHANGELOG.md
@@ -1,5 +1,14 @@
 <!-- https://developers.home-assistant.io/docs/add-ons/presentation#keeping-a-changelog -->
 
+## 2.0.4
+
+- Fixed startup crash (`mkdir /tmp/migrations: permission denied`) by setting
+  `TMPDIR=/data/tmp` and `HOME=/data` so Homebox extracts migrations to the
+  writable, AppArmor-permitted `/data` instead of `/tmp`
+- Dropped the unused positional config argument; Homebox is configured via the
+  `HBOX_*` environment variables from the base image
+- Granted the AppArmor service sub-profile access to `/tmp` as a safety net
+
 ## 2.0.3
 
 - Cleaned up metadata and documentation for the Homebox add-on

--- a/example/Dockerfile
+++ b/example/Dockerfile
@@ -4,5 +4,13 @@ FROM $BUILD_FROM
 
 LABEL org.opencontainers.image.source="https://github.com/jscarrott/homebox-addon"
 
+# The base sysadminsmedia/homebox image has no s6-overlay or bashio, so the
+# rootfs service script never runs. Point Homebox's temp dir at /data, which is
+# writable and permitted by the AppArmor profile; otherwise Homebox tries to
+# extract migrations to /tmp and crashes with "mkdir /tmp/migrations: permission
+# denied". Configuration comes from the HBOX_* env vars already set in the base
+# image, so no positional config argument is needed.
+ENV TMPDIR=/data/tmp \
+    HOME=/data
+
 ENTRYPOINT ["/app/api"]
-CMD ["/data/config.yml"]

--- a/example/apparmor.txt
+++ b/example/apparmor.txt
@@ -39,6 +39,10 @@ profile homebox flags=(attach_disconnected,mediate_deleted) {
     # Access to options.json and other files within your addon
     /data/** rw,
 
+    # Temp space (Homebox extracts migrations here if TMPDIR points at it)
+    /tmp/ rw,
+    /tmp/** rwk,
+
     # Access required for service functionality
     /app/api rix,
     /bin/bash rix,

--- a/example/config.yaml
+++ b/example/config.yaml
@@ -1,6 +1,6 @@
 # https://developers.home-assistant.io/docs/add-ons/configuration#add-on-config
 name: Homebox Add-on
-version: "2.0.3"
+version: "2.0.4"
 slug: homebox
 description: Run Homebox inventory inside Home Assistant
 url: "https://github.com/jscarrott/homebox-addon"

--- a/example/rootfs/etc/services.d/homebox/run
+++ b/example/rootfs/etc/services.d/homebox/run
@@ -2,6 +2,7 @@
 # Start the Homebox service
 
 bashio::log.info "Starting Homebox"
+export HOME="/data"
 export TMPDIR="/data/tmp"
 if bashio::fs.file_exists "/data/config.yml"; then
   exec /app/api /data/config.yml


### PR DESCRIPTION
## Problem

Homebox 2.0.3 crash-loops on boot with:

```
panic: mkdir /tmp/migrations: permission denied
```

The add-on never starts, which can look like data loss — but the SQLite DB in `/data` is untouched (the service never runs far enough to read or write it).

## Root cause

The base `sysadminsmedia/homebox` image has no s6-overlay or bashio, so the `rootfs/.../services.d/homebox/run` script never executes. That means `TMPDIR` is never set, and Homebox extracts its migrations to `/tmp/migrations`. The AppArmor `homebox_service` sub-profile (where `/app/api` runs) grants `/data/** rw` but has **no** `/tmp` rule, so the `mkdir` is denied.

## Fix

- **Dockerfile**: set `TMPDIR=/data/tmp` and `HOME=/data` so migrations are extracted under `/data`, which is writable and AppArmor-permitted. Drop the unused `CMD ["/data/config.yml"]` positional argument — config comes from the `HBOX_*` env vars already set in the base image.
- **apparmor.txt**: grant the `homebox_service` sub-profile `/tmp` access as a safety net.
- Bump to `2.0.4` + changelog.

## Verification

Booted the exact `ghcr.io/jscarrott/homebox-addon-aarch64:2.0.3` image with `TMPDIR=/data/tmp` against a copy of real add-on data: it started cleanly (`Server is running on :7745`, healthcheck 200, no panic) and all existing data (24 items, 14 locations, 12 labels) loaded and survived the schema migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)