### PR TITLE
Fix SQLITE_BUSY startup crash: grant AppArmor mmap+lock on /data

### DIFF
--- a/example/CHANGELOG.md
+++ b/example/CHANGELOG.md
@@ -1,5 +1,13 @@
 <!-- https://developers.home-assistant.io/docs/add-ons/presentation#keeping-a-changelog -->
 
+## 2.0.5
+
+- Fixed second startup crash (`database is locked (SQLITE_BUSY)`) by granting the
+  AppArmor profile mmap + lock permissions on `/data` (`/data/** rwmk`). SQLite's
+  WAL mode requires file locking and shared-memory mmap on `homebox.db` and its
+  `-wal`/`-shm` sidecars; the inner service sub-profile previously allowed only
+  `rw`, so Homebox could open the database but never lock it
+
 ## 2.0.4
 
 - Fixed startup crash (`mkdir /tmp/migrations: permission denied`) by setting

--- a/example/apparmor.txt
+++ b/example/apparmor.txt
@@ -24,8 +24,10 @@ profile homebox flags=(attach_disconnected,mediate_deleted) {
   /usr/lib/bashio/** ix,
   /tmp/** rwk,
 
-  # Access to options.json and other files within your addon
-  /data/** rw,
+  # Access to options.json and other files within your addon.
+  # rwmk: SQLite's WAL mode needs file locking (k) and shared-memory
+  # mmap (m) on homebox.db and its -wal/-shm sidecars.
+  /data/** rwmk,
 
   # Start new profile for service
   /app/api cx -> homebox_service,
@@ -36,8 +38,12 @@ profile homebox flags=(attach_disconnected,mediate_deleted) {
     # Receive signals from S6-Overlay
     signal (receive) peer=*_homebox,
 
-    # Access to options.json and other files within your addon
-    /data/** rw,
+    # Access to options.json and other files within your addon.
+    # rwmk is required: Homebox opens homebox.db in SQLite WAL mode, which
+    # needs file locking (k) plus shared-memory mmap (m) on the db and its
+    # -wal/-shm sidecars. Without these the service panics on startup with
+    # "database is locked (SQLITE_BUSY)".
+    /data/** rwmk,
 
     # Temp space (Homebox extracts migrations here if TMPDIR points at it)
     /tmp/ rw,

--- a/example/config.yaml
+++ b/example/config.yaml
@@ -1,6 +1,6 @@
 # https://developers.home-assistant.io/docs/add-ons/configuration#add-on-config
 name: Homebox Add-on
-version: "2.0.4"
+version: "2.0.5"
 slug: homebox
 description: Run Homebox inventory inside Home Assistant
 url: "https://github.com/jscarrott/homebox-addon"


### PR DESCRIPTION
## Problem

After the TMPDIR fix in #28, Homebox 2.0.4 still crash-loops on boot:

```
ERR failed creating schema resources error="sqlite: check foreign_keys pragma: reading schema information database is locked (5) (SQLITE_BUSY)"
panic: sqlite: check foreign_keys pragma: reading schema information database is locked (5) (SQLITE_BUSY)
```

## Root cause

Homebox opens `homebox.db` in SQLite **WAL mode** (`journal_mode=WAL`). WAL requires POSIX file **locking** (AppArmor `k`) and shared-memory **mmap** (`m`) on the database file and its `-wal`/`-shm` sidecars.

The inner `homebox_service` sub-profile (where `/app/api` runs under the supervisor) granted only `/data/** rw` — no `k`, no `m`. So the service could *open* the database but never *lock* it, and panicked. The outer profile hid this in manual testing because its catch-all `file,` rule already implies lock/mmap.

### How it was diagnosed

On-device tracing (host PID namespace) showed the `api` process opening `homebox.db` but **never creating `-wal`/`-shm` and never taking a lock** before failing — the signature of a denied lock. A plain `docker run` with `--security-opt apparmor=<profile>` lands the process in the *outer* profile (with `file,`) and boots fine; only the supervisor's launch, which transitions into the restricted inner sub-profile, fails. Data bytes, filesystem, and all HostConfig options were ruled out by booting byte-identical copies successfully.

## Fix

Grant `/data/** rwmk` in both the outer and inner profiles.

## Verification

Confirmed the data itself is intact throughout (24 items / 14 locations / 12 labels, `PRAGMA integrity_check` = ok). A fresh container with the lock/mmap permission boots cleanly and serves the existing inventory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)