### PR TITLE
Update Homebox to v0.25.0 (drop armv7)

### DIFF
--- a/example/CHANGELOG.md
+++ b/example/CHANGELOG.md
@@ -1,5 +1,16 @@
 <!-- https://developers.home-assistant.io/docs/add-ons/presentation#keeping-a-changelog -->
 
+## 2.1.0
+
+- Updated Homebox to **v0.25.0** (from 0.16.0). First boot runs several
+  forward-only schema migrations; existing data is preserved (the former
+  `labels` table is migrated to `tags`). Back up before updating.
+- Pinned both architectures to the same `ghcr.io/sysadminsmedia/homebox:0.25.0`
+  multi-arch image (previously aarch64/armv7 used `0.16-arm` and amd64 used
+  `latest`)
+- Dropped the `armv7` architecture — upstream Homebox no longer publishes 32-bit
+  arm images (0.25.0 provides only amd64 and arm64/aarch64)
+
 ## 2.0.5
 
 - Fixed second startup crash (`database is locked (SQLITE_BUSY)`) by granting the

--- a/example/build.yaml
+++ b/example/build.yaml
@@ -1,8 +1,7 @@
 # https://developers.home-assistant.io/docs/add-ons/configuration#add-on-dockerfile
 build_from:
-  aarch64: "ghcr.io/sysadminsmedia/homebox:0.16-arm"
-  amd64: "ghcr.io/sysadminsmedia/homebox:latest"
-  armv7: "ghcr.io/sysadminsmedia/homebox:0.16-arm"
+  aarch64: "ghcr.io/sysadminsmedia/homebox:0.25.0"
+  amd64: "ghcr.io/sysadminsmedia/homebox:0.25.0"
 labels:
   org.opencontainers.image.title: "Home Assistant Add-on: Homebox"
   org.opencontainers.image.description: "Run Homebox inside Home Assistant"

--- a/example/config.yaml
+++ b/example/config.yaml
@@ -1,11 +1,10 @@
 # https://developers.home-assistant.io/docs/add-ons/configuration#add-on-config
 name: Homebox Add-on
-version: "2.0.5"
+version: "2.1.0"
 slug: homebox
 description: Run Homebox inventory inside Home Assistant
 url: "https://github.com/jscarrott/homebox-addon"
 arch:
-  - armv7
   - aarch64
   - amd64
 ports:


### PR DESCRIPTION
## Summary

Bumps the bundled Homebox app from **0.16.0 → v0.25.0** (latest stable, 2026-04-13).

- Pin both architectures to the same multi-arch image `ghcr.io/sysadminsmedia/homebox:0.25.0` (previously aarch64/armv7 used `0.16-arm` and amd64 used the floating `latest` tag — inconsistent).
- **Drop `armv7`**: upstream 0.25.0 only publishes `amd64` and `arm64`/`aarch64`, so 32-bit arm can no longer be built. The CI matrix auto-skips arches not listed in `config.yaml`.
- Bump add-on version to **2.1.0**.

## Migration safety — verified on real data

The 0.16→0.25 jump runs forward-only `goose` migrations on first boot. I tested this against a **copy of the live database** before opening this PR:

- `goose: successfully migrated database to version 20260322121200`
- `PRAGMA integrity_check` = **ok**, API reports healthy `v0.25.0`
- Data preserved: **24 items**, **14 locations**, and the **12 labels** migrated into the renamed `tags` table (`tags=12`, `tag_items=23`)

> Note: `labels` → `tags` is an upstream rename; no label data is lost. A backup is recommended before updating regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)